### PR TITLE
Fix company name replacement method

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -48,7 +48,7 @@ jobs:
           done
 
           # Replace template name in project files
-          find . -type f \( -name "*.sln" -or -name "*.csproj" -or -name "*.cs" \) -exec sed -i "s/DeNA Co., Ltd/$GITHUB_REPOSITORY_OWNER/g" {} +
+          find . -type f \( -name "*.sln" -or -name "*.csproj" -or -name "*.cs" -or -name ".editorconfig" \) -exec sed -i "s/DeNA Co., Ltd/$GITHUB_REPOSITORY_OWNER/g" {} +
           find . -type f \( -name "*.sln" -or -name "*.csproj" -or -name "*.cs" \) -exec sed -i "s/DeNA/$GITHUB_REPOSITORY_OWNER/g" {} +
           find . -type f \( -name "*.sln" -or -name "*.csproj" -or -name "*.cs" \) -exec sed -i "s/RoslynAnalyzerTemplate/$NAME/g" {} +
           find . -type f -name "AnalyzerReleases.*.md" -exec sed -i "s/RoslynAnalyzerTemplate/$NAME/g" {} +

--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -48,6 +48,7 @@ jobs:
           done
 
           # Replace template name in project files
+          find . -type f \( -name "*.sln" -or -name "*.csproj" -or -name "*.cs" \) -exec sed -i "s/DeNA Co., Ltd/$GITHUB_REPOSITORY_OWNER/g" {} +
           find . -type f \( -name "*.sln" -or -name "*.csproj" -or -name "*.cs" \) -exec sed -i "s/DeNA/$GITHUB_REPOSITORY_OWNER/g" {} +
           find . -type f \( -name "*.sln" -or -name "*.csproj" -or -name "*.cs" \) -exec sed -i "s/RoslynAnalyzerTemplate/$NAME/g" {} +
           find . -type f -name "AnalyzerReleases.*.md" -exec sed -i "s/RoslynAnalyzerTemplate/$NAME/g" {} +


### PR DESCRIPTION
<!-- write content here -->

### Overview
- Fixed an issue where the company name was not properly replaced with the repository owner's name when generating a repository by `Use this template`.
  - For example, when I generated a repository, an unnecessary `Co., Ltd` was added at the end, such as [VeyronSakai Co., Ltd](https://github.com/VeyronSakai/DummyRoslynAnalyzer1/blob/7b5863580812f1f6e8b7ab18459654c906eb6eeb/DummyRoslynAnalyzer1/DummyRoslynAnalyzer1.cs#L1).
- I thought it would be necessary to replace .[editorconfig](https://github.com/DeNA/RoslynAnalyzerTemplate/blob/3bf2798226779c0f0688ff7130d7e8117792a710/.editorconfig#L148) as well, so I did that.

### Operation Confirmation

I added the same changes as this PR to the fork version of this repository, [VeyronSakai/RoslynAnalyzerTemplate](https://github.com/VeyronSakai/RoslynAnalyzerTemplate), and generated a repository, [DummyRoslynAnalyzer2](https://github.com/VeyronSakai/DummyRoslynAnalyzer2) by `Use this template`, and made sure that the names were replaced appropriately.

[Template cleanup commit](https://github.com/VeyronSakai/DummyRoslynAnalyzer2/commit/43da46e7e14af8bc48dcccc8f97036b19868c3f2)

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).