### PR TITLE
Clean up pull_request_template.md when generating repository

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -65,6 +65,7 @@ jobs:
             .github/template-cleanup \
             .github/workflows/template-cleanup.yml \
             .github/CODEOWNERS \
+            .github/pull_request_template.md \
             LICENSE
 
       # Commit modified files


### PR DESCRIPTION
<!-- write content here -->

### Overview

Remove pull_request_template.md when generating a repository by `Use this template`, because DeNA's Contribution License Agreement seems not to be necessary for the generated repository.

### Operation Confirmation

I added the same changes as this PR to the fork version of this repository, [VeyronSakai/RoslynAnalyzerTemplate](https://github.com/VeyronSakai/RoslynAnalyzerTemplate), and generated a repository, [DummyRoslynAnalyzer3](https://github.com/VeyronSakai/DummyRoslynAnalyzer3) by `Use this template`, and made sure that the pull_request_termplate.md were removed. ([file changed](https://github.com/VeyronSakai/DummyRoslynAnalyzer3/commit/ddcabf0bc994818aa3c4b7af9b19757164a4dbd2#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6b))

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).